### PR TITLE
Add protection from adding jobs with empty names

### DIFF
--- a/Models/Worker.js
+++ b/Models/Worker.js
@@ -34,6 +34,10 @@ export default class Worker {
    */
   addWorker(jobName, worker, options = {}) {
 
+    if (!jobName || !worker) {
+      throw new Error('Job name and associated function must be supplied.');
+    }
+
     // Attach options to worker
     worker.options = {
       concurrency: options.concurrency || 1


### PR DESCRIPTION
I encountered this problem due to a bug in our code and would have been nice to know that we were registering jobs with empty names.