### PR TITLE
Support indefinite timeout

### DIFF
--- a/Models/Queue.js
+++ b/Models/Queue.js
@@ -87,6 +87,10 @@ export class Queue {
       throw new Error('Job name must be supplied.');
     }
 
+    if (!options.timeout) {
+      options.timeout = 0;
+    }
+
     // Validate options
     if (options.timeout < 0 || options.attempts < 0) {
       throw new Error('Invalid job option.');
@@ -103,7 +107,7 @@ export class Queue {
         }),
         priority: options.priority || 0,
         active: false,
-        timeout: (options.timeout > 0) ? options.timeout : 25000,
+        timeout: options.timeout,
         created: new Date(),
         failed: null
       });

--- a/Models/Worker.js
+++ b/Models/Worker.js
@@ -34,6 +34,10 @@ export default class Worker {
    */
   addWorker(jobName, worker, options = {}) {
 
+    if (!jobName || !worker) {
+      throw new Error('Job name and associated function must be supplied.');
+    }
+
     // Attach options to worker
     worker.options = {
       concurrency: options.concurrency || 1


### PR DESCRIPTION
Although documentation claimed support for indefinite timeout, we were not able to get it to work. These fixes were done to fully support jobs with indefinite timeouts.