### PR TITLE
FIX: Remove on active job to true in getConcurrentJobs

### DIFF
--- a/Models/Queue.js
+++ b/Models/Queue.js
@@ -285,11 +285,6 @@ export class Queue {
         // See: https://stackoverflow.com/questions/47359368/does-realm-support-select-for-update-style-read-locking/47363356#comment81772710_47363356
         const concurrentJobIds = jobsToMarkActive.map( job => job.id);
 
-        // Mark concurrent jobs as active
-        jobsToMarkActive = jobsToMarkActive.map( job => {
-          job.active = true;
-        });
-
         // Reselect now-active concurrent jobs by id.
         const reselectQuery = concurrentJobIds.map( jobId => 'id == "' + jobId + '"').join(' OR ');
         const reselectedJobs = this.realm.objects('Job')
@@ -370,9 +365,6 @@ export class Queue {
         }
 
         job.data = JSON.stringify(jobData);
-
-        // Reset active status
-        job.active = false;
 
         // Mark job as failed if too many attempts
         if (jobData.failedAttempts >= jobData.attempts) {


### PR DESCRIPTION
When I used the package and I ask to run all my jobs that are within the queue. And I close my application before the first job is finished, this job is never finished when I start my application again. With this modification this problem has been fixed.